### PR TITLE
Adding parsing for @testWith + travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ env:
     - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest"
 
 before_install:
-  - ./build/tools/composer clear-cache
+  - composer clear-cache
 
 install:
-  - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry ./build/tools/composer update $DEFAULT_COMPOSER_FLAGS; fi
-  - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry ./build/tools/composer update $DEFAULT_COMPOSER_FLAGS --prefer-lowest; fi
+  - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS; fi
+  - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS --prefer-lowest; fi
 
 before_script:
   - echo 'zend.assertions=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -50,19 +50,19 @@ notifications:
 
 jobs:
   include:
-    - stage: Static Code Analysis
-      php: 7.2
-      env: PHPStan
-      before_install:
-        - travis_retry ./build/tools/composer require --no-update phpunit/php-invoker:^2.0
-      install: travis_retry ./build/tools/composer update --prefer-dist --prefer-stable
-      script:
-        - ./build/tools/phpstan analyse --level=max -c phpstan.neon src
-        - ./build/tools/phpstan analyse --level=max -c phpstan-tests.neon tests
-    - stage: Static Code Analysis
-      php: 7.2
-      env: php-cs-fixer
-      install:
-        - phpenv config-rm xdebug.ini
-      script:
-        - ./build/tools/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff
+#    - stage: Static Code Analysis
+#      php: 7.2
+#      env: PHPStan
+#      before_install:
+#        - travis_retry ./build/tools/composer require --no-update phpunit/php-invoker:^2.0
+#      install: travis_retry ./build/tools/composer update --prefer-dist --prefer-stable
+#      script:
+#        - ./build/tools/phpstan analyse --level=max -c phpstan.neon src
+#        - ./build/tools/phpstan analyse --level=max -c phpstan-tests.neon tests
+#    - stage: Static Code Analysis
+#      php: 7.2
+#      env: php-cs-fixer
+#      install:
+#        - phpenv config-rm xdebug.ini
+#      script:
+#        - ./build/tools/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,68 @@
+language: php
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libxml2-utils
+
+php:
+  - 7.2
+  - master
+
+matrix:
+  allow_failures:
+    - php: master
+  fast_finish: true
+
+env:
+  matrix:
+    - DEPENDENCIES="high"
+    - DEPENDENCIES="low"
+  global:
+    - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest"
+
+before_install:
+  - ./build/tools/composer clear-cache
+
+install:
+  - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry ./build/tools/composer update $DEFAULT_COMPOSER_FLAGS; fi
+  - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry ./build/tools/composer update $DEFAULT_COMPOSER_FLAGS --prefer-lowest; fi
+
+before_script:
+  - echo 'zend.assertions=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'assert.exception=On' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+script:
+  - ./vendor/bin/phpunit --coverage-clover=coverage.xml
+  - ./vendor/bin/phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
+  - xmllint --noout --schema phpunit.xsd phpunit.xml
+  - xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml
+  - xmllint --noout --schema phpunit.xsd tests/_files/configuration_empty.xml
+  - xmllint --noout --schema phpunit.xsd tests/_files/configuration_xinclude.xml -xinclude
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+notifications:
+  email: false
+
+jobs:
+  include:
+    - stage: Static Code Analysis
+      php: 7.2
+      env: PHPStan
+      before_install:
+        - travis_retry ./build/tools/composer require --no-update phpunit/php-invoker:^2.0
+      install: travis_retry ./build/tools/composer update --prefer-dist --prefer-stable
+      script:
+        - ./build/tools/phpstan analyse --level=max -c phpstan.neon src
+        - ./build/tools/phpstan analyse --level=max -c phpstan-tests.neon tests
+    - stage: Static Code Analysis
+      php: 7.2
+      env: php-cs-fixer
+      install:
+        - phpenv config-rm xdebug.ini
+      script:
+        - ./build/tools/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover=coverage.xml
-  - ./vendor/bin/phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
-  - xmllint --noout --schema phpunit.xsd phpunit.xml
-  - xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml
-  - xmllint --noout --schema phpunit.xsd tests/_files/configuration_empty.xml
-  - xmllint --noout --schema phpunit.xsd tests/_files/configuration_xinclude.xml -xinclude
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
@@ -48,21 +43,29 @@ after_success:
 notifications:
   email: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache/
+
 jobs:
   include:
-#    - stage: Static Code Analysis
-#      php: 7.2
-#      env: PHPStan
-#      before_install:
-#        - travis_retry ./build/tools/composer require --no-update phpunit/php-invoker:^2.0
-#      install: travis_retry ./build/tools/composer update --prefer-dist --prefer-stable
-#      script:
-#        - ./build/tools/phpstan analyse --level=max -c phpstan.neon src
-#        - ./build/tools/phpstan analyse --level=max -c phpstan-tests.neon tests
-#    - stage: Static Code Analysis
-#      php: 7.2
-#      env: php-cs-fixer
-#      install:
-#        - phpenv config-rm xdebug.ini
-#      script:
-#        - ./build/tools/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff
+    - stage: Static Code Analysis
+      php: 7.2
+      name: "PHP Codesniffer: PSR2"
+      before_install:
+        - phpenv config-rm xdebug.ini || true
+        - mkdir ../tools && composer init --name=phpu/tools --working-dir=../tools
+        - composer require friendsofphp/php-cs-fixer:^2.12 --working-dir=../tools
+      install: true
+      script:
+        - ../tools/vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff
+    - stage: Static Code Analysis
+      php: 7.2
+      name: PHPstan
+      before_install:
+        - phpenv config-rm xdebug.ini || true
+        - mkdir ../tools && composer init --name=phpu/tools --working-dir=../tools
+        - composer require phpstan/phpstan:^0.10 --working-dir=../tools
+      install: composer update
+      script:
+        - ../tools/vendor/bin/phpstan analyse --level max src tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
   include:
     - stage: Static Code Analysis
       php: 7.2
-      name: "PHP Codesniffer: PSR2"
+      name: PHP Cs Fixer
       before_install:
         - phpenv config-rm xdebug.ini || true
         - mkdir ../tools && composer init --name=phpu/tools --working-dir=../tools

--- a/src/Finder/FilesystemCache.php
+++ b/src/Finder/FilesystemCache.php
@@ -34,7 +34,7 @@ final class FilesystemCache implements Cache
     public function get(string $sourceFile): TestCollection
     {
         return \unserialize(
-            \file_get_contents($this->cacheFile($sourceFile)),
+            \file_get_contents($this->cacheFile($sourceFile)) ?: '',
             [
                 TestCollection::class,
                 TestMethod::class

--- a/src/Finder/TestFinder.php
+++ b/src/Finder/TestFinder.php
@@ -175,7 +175,7 @@ final class TestFinder
             $numMatches = \count($matches[0]);
 
             for ($i = 0; $i < $numMatches; ++$i) {
-                if ($matches['name'] === 'testWith') {
+                if ($matches['name'][$i] === 'testWith') {
                     continue;
                 }
                 $annotations->add(

--- a/src/Finder/TestFinder.php
+++ b/src/Finder/TestFinder.php
@@ -169,7 +169,7 @@ final class TestFinder
     private function annotations(string $docBlock): AnnotationCollection
     {
         $annotations = new AnnotationCollection;
-        $docBlock    = (string) \substr($docBlock, 3, -2);
+        $docBlock    = \substr($docBlock, 3, -2);
 
         if (\preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docBlock, $matches)) {
             $numMatches = \count($matches[0]);
@@ -186,11 +186,11 @@ final class TestFinder
                 );
             }
             if (\preg_match_all('/@(?P<name>testWith)[\t ](?P<value>(\[.*?\]|[\n\r]+[\t ]*\*[\t ]+)+)/', $docBlock, $matches)) {
-                foreach($matches['value'] as $value) {
+                foreach ($matches['value'] as $value) {
                     $annotations->add(
                         new Annotation(
                             'testWith',
-                            '[' . implode(',', preg_split('/[ \t]*[\r\n][ \t]*\*[ \t]*/', $value)) . ']'
+                            '[' . \implode(',', \preg_split('/[ \t]*[\r\n][ \t]*\*[ \t]*/', $value) ?: '') . ']'
                         )
                     );
                 }

--- a/src/Finder/TestFinder.php
+++ b/src/Finder/TestFinder.php
@@ -170,6 +170,7 @@ final class TestFinder
     {
         $annotations = new AnnotationCollection;
         $docBlock    = \substr($docBlock, 3, -2);
+
         if (!$docBlock) {
             return $annotations;
         }
@@ -188,12 +189,13 @@ final class TestFinder
                     )
                 );
             }
+
             if (\preg_match_all('/@(?P<name>testWith)[\t ](?P<value>(\[.*?\]|[\n\r]+[\t ]*\*[\t ]+)+)/', $docBlock, $matches)) {
                 foreach ($matches['value'] as $value) {
                     $annotations->add(
                         new Annotation(
                             'testWith',
-                            '[' . \implode(',', \preg_split('/[ \t]*[\r\n][ \t]*\*[ \t]*/', $value) ?: '') . ']'
+                            '[' . \implode(',', \preg_split('/[ \t]*[\r\n][ \t]*\*[ \t]*/', $value) ?: []) . ']'
                         )
                     );
                 }

--- a/src/Finder/TestFinder.php
+++ b/src/Finder/TestFinder.php
@@ -170,6 +170,9 @@ final class TestFinder
     {
         $annotations = new AnnotationCollection;
         $docBlock    = \substr($docBlock, 3, -2);
+        if (!$docBlock) {
+            return $annotations;
+        }
 
         if (\preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docBlock, $matches)) {
             $numMatches = \count($matches[0]);

--- a/src/Finder/TestFinder.php
+++ b/src/Finder/TestFinder.php
@@ -175,12 +175,25 @@ final class TestFinder
             $numMatches = \count($matches[0]);
 
             for ($i = 0; $i < $numMatches; ++$i) {
+                if ($matches['name'] === 'testWith') {
+                    continue;
+                }
                 $annotations->add(
                     new Annotation(
                         (string) $matches['name'][$i],
                         (string) $matches['value'][$i]
                     )
                 );
+            }
+            if (\preg_match_all('/@(?P<name>testWith)[\t ](?P<value>(\[.*?\]|[\n\r]+[\t ]*\*[\t ]+)+)/', $docBlock, $matches)) {
+                foreach($matches['value'] as $value) {
+                    $annotations->add(
+                        new Annotation(
+                            'testWith',
+                            '[' . implode(',', preg_split('/[ \t]*[\r\n][ \t]*\*[ \t]*/', $value)) . ']'
+                        )
+                    );
+                }
             }
         }
 

--- a/tests/_fixture/TestWithTest.php
+++ b/tests/_fixture/TestWithTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\NewRunner\TestFixture;
+
+final class TestWithTest extends MyTestCase
+{
+    /**
+     * @testWith [1]
+     *           [8]
+     *           [12]
+     */
+    public function testSeven($value): void
+    {
+        $this->assertInternalType('int', $value);
+    }
+}

--- a/tests/unit/Finder/TestFinderTest.php
+++ b/tests/unit/Finder/TestFinderTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\NewRunner\TestFixture\BarTest;
 use PHPUnit\NewRunner\TestFixture\FooTest;
 use PHPUnit\NewRunner\TestFixture\MyTestCase;
+use PHPUnit\NewRunner\TestFixture\TestWithTest;
 
 /**
  * @covers PHPUnit\NewRunner\TestFinder
@@ -167,6 +168,25 @@ final class TestFinderTest extends TestCase
                     new Annotation(
                         'covers',
                         'Bar'
+                    )
+                ),
+                AnnotationCollection::fromArray()
+            ),
+            $tests,
+            '',
+            false,
+            false
+        );
+
+        $this->assertContains(
+            new TestMethod(
+                $this->fixtureDirectory . '/' . 'TestWithTest.php',
+                TestWithTest::class,
+                'testTwo',
+                AnnotationCollection::fromArray(
+                    new Annotation(
+                        'testWith',
+                        '[[1],[8],[12]]'
                     )
                 ),
                 AnnotationCollection::fromArray()

--- a/tests/unit/Finder/TestFinderTest.php
+++ b/tests/unit/Finder/TestFinderTest.php
@@ -47,7 +47,7 @@ final class TestFinderTest extends TestCase
 
         $this->finder = new TestFinder($cache);
 
-        $this->fixtureDirectory = \realpath(__DIR__ . '/../../_fixture');
+        $this->fixtureDirectory = (string) \realpath(__DIR__ . '/../../_fixture');
     }
 
     public function testFindsTestMethods(): void
@@ -56,7 +56,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'FooTest.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'FooTest.php',
                 FooTest::class,
                 'testOne',
                 AnnotationCollection::fromArray(
@@ -75,7 +75,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'FooTest.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'FooTest.php',
                 FooTest::class,
                 'testTwo',
                 AnnotationCollection::fromArray(
@@ -99,7 +99,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'FooTest.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'FooTest.php',
                 FooTest::class,
                 'testThree',
                 AnnotationCollection::fromArray(
@@ -123,7 +123,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertNotContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'MyTestCase.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'MyTestCase.php',
                 MyTestCase::class,
                 'testOne',
                 AnnotationCollection::fromArray(
@@ -142,7 +142,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'BarTest.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'BarTest.php',
                 BarTest::class,
                 'testOne',
                 AnnotationCollection::fromArray(
@@ -161,7 +161,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'BarTest.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'BarTest.php',
                 BarTest::class,
                 'testTwo',
                 AnnotationCollection::fromArray(
@@ -180,7 +180,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'TestWithTest.php',
+                $this->fixtureDirectory . \DIRECTORY_SEPARATOR . 'TestWithTest.php',
                 TestWithTest::class,
                 'testSeven',
                 AnnotationCollection::fromArray(),

--- a/tests/unit/Finder/TestFinderTest.php
+++ b/tests/unit/Finder/TestFinderTest.php
@@ -56,7 +56,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'FooTest.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'FooTest.php',
                 FooTest::class,
                 'testOne',
                 AnnotationCollection::fromArray(
@@ -75,7 +75,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'FooTest.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'FooTest.php',
                 FooTest::class,
                 'testTwo',
                 AnnotationCollection::fromArray(
@@ -99,7 +99,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'FooTest.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'FooTest.php',
                 FooTest::class,
                 'testThree',
                 AnnotationCollection::fromArray(
@@ -123,7 +123,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertNotContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'MyTestCase.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'MyTestCase.php',
                 MyTestCase::class,
                 'testOne',
                 AnnotationCollection::fromArray(
@@ -142,7 +142,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'BarTest.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'BarTest.php',
                 BarTest::class,
                 'testOne',
                 AnnotationCollection::fromArray(
@@ -161,7 +161,7 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'BarTest.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'BarTest.php',
                 BarTest::class,
                 'testTwo',
                 AnnotationCollection::fromArray(
@@ -180,16 +180,16 @@ final class TestFinderTest extends TestCase
 
         $this->assertContains(
             new TestMethod(
-                $this->fixtureDirectory . '/' . 'TestWithTest.php',
+                $this->fixtureDirectory . DIRECTORY_SEPARATOR . 'TestWithTest.php',
                 TestWithTest::class,
                 'testSeven',
+                AnnotationCollection::fromArray(),
                 AnnotationCollection::fromArray(
                     new Annotation(
                         'testWith',
                         '[[1],[8],[12]]'
                     )
-                ),
-                AnnotationCollection::fromArray()
+                )
             ),
             $tests,
             '',

--- a/tests/unit/Finder/TestFinderTest.php
+++ b/tests/unit/Finder/TestFinderTest.php
@@ -182,7 +182,7 @@ final class TestFinderTest extends TestCase
             new TestMethod(
                 $this->fixtureDirectory . '/' . 'TestWithTest.php',
                 TestWithTest::class,
-                'testTwo',
+                'testSeven',
                 AnnotationCollection::fromArray(
                     new Annotation(
                         'testWith',


### PR DESCRIPTION
you might want to squash this.

travis config is based on the phpunit one, with the slight difference of not carriing along the static analysers and instead caching the composer cache between builds.